### PR TITLE
src/cbang/openssl/Digest.h: libressl compat

### DIFF
--- a/src/cbang/openssl/Digest.h
+++ b/src/cbang/openssl/Digest.h
@@ -41,7 +41,9 @@
 
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#if defined(LIBRESSL_VERSION_NUMBER)
+#include <openssl/evp.h>
+#elif OPENSSL_VERSION_NUMBER < 0x1010000fL
 typedef struct env_md_st EVP_MD;
 typedef struct env_md_ctx_st EVP_MD_CTX;
 #else


### PR DESCRIPTION
For compatibility with libressl[1] first check for the LIBRESSL_VERSION_NUMBER
macro being defined. In case it is defined simply include openssl/evp.h
which defines the EVP_MD and EVP_MD_CTX types.

[1] https://www.libressl.org/