### PR TITLE
Minor fixes to make cbang build w/ Musl libc

### DIFF
--- a/src/cbang/String.cpp
+++ b/src/cbang/String.cpp
@@ -56,7 +56,7 @@ using namespace cb;
 #define strtoull(p, e, b) _strtoui64(p, e, b)
 #define strtof(p, e) (float)strtod(p, e)
 #define vsnprintf _vsnprintf
-#define __va_copy(x, y) (x = y)
+#define va_copy(x, y) (x = y)
 #endif
 
 const string String::DEFAULT_DELIMS = " \t\n\r";
@@ -116,7 +116,7 @@ string String::printf(const char *format, ...) {
 
 string String::vprintf(const char *format, va_list ap) {
   va_list copy;
-  __va_copy(copy, ap);
+  va_copy(copy, ap);
 
   int length = vsnprintf(0, 0, format, copy);
   va_end(copy);

--- a/src/cbang/os/Thread.cpp
+++ b/src/cbang/os/Thread.cpp
@@ -214,7 +214,7 @@ void Thread::kill(int signal) {
 void Thread::yield() {
 #ifdef _WIN32
   SwitchToThread();
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || !defined(__GLIBC__)
   sched_yield();
 #else
   pthread_yield();

--- a/src/cbang/time/Timer.h
+++ b/src/cbang/time/Timer.h
@@ -37,10 +37,12 @@
 #undef min
 #endif // _WIN32
 
-
+#if defined(__GLIBC__)
 struct timeval;
 struct timespec;
-
+#else
+#include <sys/time.h>
+#endif
 
 namespace cb {
   /// Time events or access current system time


### PR DESCRIPTION
+ Use va_copy() instead of __va_copy(), which is an internal name
+ Include sys/time.h instead of declaring struct timeval and struct timespec
+ Use sched_yield() instead of pthread_yield() w/ Musl libc

It should also be possible to '#define _GNU_SOURCE' prior to including
pthread.h to have pthread_yield(3) defined.

Also note that the pthread_yield(3) manual page itself suggests to use
the standardized sched_yield(2) because pthread_yield() is nonstandard.