### PR TITLE
[WIP] Mac, aarch64 coverage on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,45 @@ addons:
       - libleveldb-dev
       - libsnappy-dev
       - git
+  homebrew:
+    update: true
+    packages:
+      - scons
+      - binutils
+      - mariadb
+      - leveldb
+      - snappy
 
 jobs:
   include:
     - stage: Build
-      script:
+      os: linux
+      dist: bionic
+      script: &build
         - scons
+    - stage: Build
+      os: linux
+      dist: bionic
+      arch: arm64
+      script: *build
+    - stage: Build
+      os: osx
+      osx_image: xcode11.3
+      script: *build
     - stage: Test
-      script:
+      os: linux
+      dist: bionic
+      script: &test
         - scons
         - cd tests
         - scons
         - ./testHarness
+    - stage: Test
+      os: linux
+      dist: bionic
+      arch: arm64
+      script: *test
+    - stage: Test
+      os: osx
+      osx_image: xcode11.3
+      script: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: bionic
 language: cpp
 compiler:
-  - gcc
+  - clang
 python:
   - "3.8"
 
@@ -44,8 +44,12 @@ jobs:
       script: *build
     - stage: Build
       os: osx
-      osx_image: xcode11.3
-      script: *build
+      script:
+        - scons -H
+        - scons
+    # - stage: Build
+    #   os: windows
+    #   script: *build
     - stage: Test
       os: linux
       dist: bionic
@@ -61,5 +65,7 @@ jobs:
       script: *test
     - stage: Test
       os: osx
-      osx_image: xcode11.3
       script: *test
+    # - stage: Test
+    #   os: windows
+    #   script: *test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 C! (a.k.a. C-Bang)
 ==================
 
-[![Build Status](https://travis-ci.org/CauldronDevelopmentLLC/cbang.svg?branch=master)](https://travis-ci.org/CauldronDevelopmentLLC/cbang)
+[![Build Status](https://travis-ci.com/CauldronDevelopmentLLC/cbang.svg?branch=master)](https://travis-ci.com/CauldronDevelopmentLLC/cbang)
 
 The C! or cbang library is a collection of C++ utility libraries
 developed over the course of +15 years and several major C++


### PR DESCRIPTION
On Mac, I can't get past this error:
```
Checking for C library pthread... no
Exception: Need library pthread:
```

https://travis-ci.com/github/peterbecich/cbang/jobs/318015866

Any ideas?