### PR TITLE
My suggested set of flags for MSVC for maximum optimizations

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -308,7 +308,7 @@ def configure(conf, cstd = 'c99'):
             env.AppendUnique(CCFLAGS = ['-O3', '-funroll-loops'])
 
         elif compiler_mode == 'msvc':
-            env.AppendUnique(CCFLAGS = ['/Ox'])
+            env.AppendUnique(CCFLAGS = ['/O2', '/Ob3', '/Zc:throwingNew'])
             if compiler == 'intel' and not globalopt:
                 env.AppendUnique(LINKFLAGS = ['/Qnoipo'])
 


### PR DESCRIPTION
Ox is kind of old and busted
Ob3 changes the inliner threshholds to be closer to the level of aggressiveness seen in other compilers (this will one day be the default for /O2)
Zc:throwingNew allows the compiler to assume that operator new doesn't return nullptr on failure and instead throws, which is nice, because operator new has always worked this way in every standard compiler ever (this is a holdover from VC6, and will also be the default someday)