### PR TITLE
Allow to specify 'strip' executable

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -44,6 +44,7 @@ def configure(conf, cstd = 'c99'):
     cc = env.get('cc', '').strip()
     cxx = env.get('cxx', '').strip()
     ranlib = env.get('ranlib', '').strip()
+    strip = env.get('strip', '').strip()
     debug = int(env.get('debug'))
     optimize = int(env.get('optimize'))
     if optimize == -1: optimize = not debug
@@ -135,6 +136,7 @@ def configure(conf, cstd = 'c99'):
             env.Replace(CC = 'i586-mingw32msvc-gcc')
             env.Replace(CXX = 'i586-mingw32msvc-g++')
             env.Replace(RANLIB = 'i586-mingw32msvc-ranlib')
+            env.Replace(STRIP = 'i586-mingw32msvc-strip')
             env.Replace(PROGSUFFIX = '.exe')
             compiler_mode = 'gnu'
 
@@ -174,6 +176,7 @@ def configure(conf, cstd = 'c99'):
     if cc: env.Replace(CC = cc)
     if cxx: env.Replace(CXX = cxx)
     if ranlib: env.Replace(RANLIB = ranlib)
+    if strip: env.Replace(STRIP = strip)
 
     env.__setitem__('compiler', compiler)
     env.__setitem__('compiler_mode', compiler_mode)
@@ -595,6 +598,7 @@ def generate(env):
         ('cc', 'Set C compiler executable', ''),
         ('cxx', 'Set C++ compiler executable', ''),
         ('ranlib', 'Set ranlib executable', ''),
+        ('strip', 'Set strip executable', ''),
         ('optimize', 'Enable or disable optimizations', -1),
         ('globalopt', 'Enable or disable global optimizations', 0),
         ('mach', 'Set machine instruction set', ''),

--- a/config/deb/__init__.py
+++ b/config/deb/__init__.py
@@ -138,7 +138,7 @@ def build_function(target, source, env):
     if not int(env.get('debug')):
         for src, dst, mode in get_files(env, 'programs',
                                         build_dir + '/usr/bin'):
-            CommandAction('strip ' + dst).execute(dst, [dst], env)
+            CommandAction(env.get('STRIP', 'strip') + ' ' + dst).execute(dst, [dst], env)
 
     # Create debian control
     total_size = get_total_file_size(build_dir)

--- a/config/rpm/__init__.py
+++ b/config/rpm/__init__.py
@@ -85,6 +85,8 @@ def build_function(target, source, env):
         # Description
         write_spec_text_section(f, env, 'description', 'description')
 
+        f.write('%define strip ' + env.get('STRIP', 'strip') + '\n\n')
+
         # Scripts
         for script in ['prep', 'build', 'install', 'clean', 'pre', 'post',
                        'preun', 'postun', 'verifyscript']:


### PR DESCRIPTION
This is needed for cross-building deb and rpm packages - i.e., building of aarch64 package on x86_64 host and vice versa.