### PR TITLE
Add variable osx_min_ver to packager

### DIFF
--- a/config/packager/__init__.py
+++ b/config/packager/__init__.py
@@ -304,6 +304,7 @@ def generate(env):
             ('sign_id_installer', 'Installer signature name'),
             ('sign_id_app', 'Application/Tool signature name'),
             ('sign_prefix', 'codesign identifier prefix'),
+            ('osx_min_ver', 'Set minimum support OSX version.', '10.7'),
             )
 
     env.SetDefault(PACKAGE_EXCLUDES = ['.svn', '.sconsign.dblite',


### PR DESCRIPTION
Not tested, because my build env is still broken.
I have high confidence this is correct and lacks errors, because it was copied from cbang/config/compiler.
