### PR TITLE
Update flatdistpkg archs

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -449,7 +449,7 @@ def configure(conf, cstd = 'c99'):
     # For darwin
     if env['PLATFORM'] == 'darwin' or int(env.get('cross_osx', 0)):
         env.CBDefine('__APPLE__')
-        if osx_archs and compiler == 'gnu':
+        if osx_archs and compiler_mode == 'gnu':
             # note: only apple compilers support multipe -arch options
             for arch in osx_archs.split():
                 env.Append(CCFLAGS = ['-arch', arch])


### PR DESCRIPTION
Add dep compiler to get osx_archs.
Do not use package_arch; it is for the file name.
Use osx_archs as default for distpkg_arch.
Also handle aberrant value 'universal'.
Support multi archs in pkg hostArchitectures.
Update some text in installer script.
Do not patch distribution xml if target is macOS 10.6.6+.