### PR TITLE
Allow env vars for RUN_DISTUTILS

### DIFF
--- a/config/run_distutils/__init__.py
+++ b/config/run_distutils/__init__.py
@@ -1,12 +1,15 @@
 from SCons.Script import *
+import os
 
 
 def generate(env):
     env.SetDefault(RUN_DISTUTILS = 'python')
     env.SetDefault(RUN_DISTUTILSOPTS = 'build')
 
-    env['RUN_DISTUTILS'] = 'python'
-    env['RUN_DISTUTILSOPTS'] = 'build'
+    if 'RUN_DISTUTILS' in os.environ:
+        env['RUN_DISTUTILS'] = os.environ['RUN_DISTUTILS']
+    if 'RUN_DISTUTILSOPTS' in os.environ:
+        env['RUN_DISTUTILSOPTS'] = os.environ['RUN_DISTUTILSOPTS']
 
     bld = Builder(action = '$RUN_DISTUTILS $SOURCE $RUN_DISTUTILSOPTS')
     env.Append(BUILDERS = {'RunDistUtils' : bld})


### PR DESCRIPTION
Allow use of env vars RUN_DISTUTILS, RUN_DISTUTILOPTS as defaults.

With this, on macos, macports doesn't need to be in PATH to build FAHControl. One just needs

export RUN_DISTUTILS="/opt/local/bin/python"

or the equivalent in dockbot.json env.