### PR TITLE
Use absolute paths in dlopen on macOS

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -295,7 +295,9 @@ def configure(conf, cstd = 'c99'):
 
     else:
         if compiler_mode == 'gnu': # Strip symbols
-            env.AppendUnique(LINKFLAGS = ['-Wl,-s', '-Wl,-x'])
+            if compiler != 'clang':
+                env.AppendUnique(LINKFLAGS = ['-Wl,-s'])
+            env.AppendUnique(LINKFLAGS = ['-Wl,-x'])
 
         if compiler == 'gnu': # Enable dead code removal
             env.AppendUnique(LINKFLAGS = ['-Wl,--gc-sections'])
@@ -383,7 +385,8 @@ def configure(conf, cstd = 'c99'):
     # No PIE with GCC 6+
     if compiler_mode == 'gnu' and (5,) <= gcc_version(env):
         env.AppendUnique(CCFLAGS = '-fno-pie')
-        env.AppendUnique(LINKFLAGS = '-no-pie')
+        if compiler != 'clang':
+            env.AppendUnique(LINKFLAGS = '-no-pie')
 
 
     # C mode

--- a/src/cbang/gpu/CUDALibrary.cpp
+++ b/src/cbang/gpu/CUDALibrary.cpp
@@ -49,7 +49,8 @@ static const char *cudaLib = "nvcuda.dll";
 #define STDCALL __stdcall
 
 #elif __APPLE__
-static const char *cudaLib = "libcuda.dylib";
+// if supported, would be "/usr/local/cuda/lib/libcuda.dylib"
+static const char *cudaLib = "";
 #define STDCALL
 
 #else

--- a/src/cbang/gpu/OpenCLLibrary.cpp
+++ b/src/cbang/gpu/OpenCLLibrary.cpp
@@ -51,7 +51,7 @@ using namespace cb;
 static const char *openclLib = "OpenCL.dll";
 
 #elif __APPLE__
-static const char *openclLib = "libOpenCL.dylib";
+static const char *openclLib = "/System/Library/Frameworks/OpenCL.framework/OpenCL";
 
 size_t strnlen(const char *s, size_t n) {
   size_t l = 0;

--- a/src/cbang/os/DynamicLibrary.cpp
+++ b/src/cbang/os/DynamicLibrary.cpp
@@ -77,6 +77,9 @@ DynamicLibrary::DynamicLibrary(const string &path) :
 #else
   dlerror(); // Clear errors
 
+  if (path.empty())
+    THROW("Library path is ''");
+
   pri->handle = dlopen(path.c_str(), RTLD_LAZY);
   if (!pri->handle)
     THROW("Failed to open dynamic library '" << path << "': " << dlerror());


### PR DESCRIPTION
On macOS with hardened runtime, relative paths are not allowed in dlopen.

Add full path to OpenCL framework.
Change CUDA path to ''.

Throw exception if dlopen path is empty.

Fix clang warnings:
  unused -no-pie
  obsolete -Wl,-s