### PR TITLE
Fix clang warnings

### DIFF
--- a/src/re2/SConscript
+++ b/src/re2/SConscript
@@ -6,7 +6,9 @@ if not env.GetOption('clean'):
     env.Append(CPPPATH = ['#/src/re2/src'])
 
     if env.get('compiler_mode') == 'gnu':
-        env.Append(CXXFLAGS = ['-Wno-class-memaccess', '-Wno-parentheses'])
+        if env.get('compiler') != 'clang':
+            env.Append(CXXFLAGS = ['-Wno-class-memaccess'])
+        env.Append(CXXFLAGS = ['-Wno-parentheses'])
 
     if env['PLATFORM'] == 'win32': env.CBDefine('NOMINMAX')
 


### PR DESCRIPTION
Fix clang warnings:
unknown -Wno-class-memaccess

clang++ -o build/re2/src/re2/parse.o -c -faligned-new -std=c++14 -fsigned-char -Wno-class-memaccess -Wno-parentheses -O3 -funroll-loops -fno-pie -arch x86_64 -mmacosx-version-min=10.7 -stdlib=libc++ -Wno-unused-local-typedefs -fPIC -DNDEBUG -D_REENTRANT -D__APPLE__ -DUSING_CBANG -I/Users/kevin2/fah-local-10.7-universal/include -Iinclude -Isrc -Isrc/boost -Isrc/re2/src src/re2/src/re2/parse.cc
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]