### PR TITLE
Add OSX Security framework, verify and add anchor certs

### DIFF
--- a/config/cbang/__init__.py
+++ b/config/cbang/__init__.py
@@ -59,9 +59,10 @@ def configure_deps(conf, local = True, with_openssl = True):
     if env['PLATFORM'] == 'darwin' or int(env.get('cross_osx', 0)):
         if not (conf.CheckOSXFramework('CoreServices') and
                 conf.CheckOSXFramework('IOKit') and
+                conf.CheckOSXFramework('Security') and
                 conf.CheckOSXFramework('CoreFoundation')):
             raise SCons.Errors.StopError(
-                'Need CoreServices, IOKit & CoreFoundation frameworks')
+                'Need CoreServices, IOKit, Security & CoreFoundation frameworks')
 
     conf.CBConfig('valgrind', False)
 


### PR DESCRIPTION
Add OSX Security framework
Verify and add anchor certs
On OSX, use default 32 KiB socket buffers

This compiles cleanly, and seems to work properly on macOS 10.15.7.

TODO

- test on macOS 12
- test on macOS 10.11 or earlier, where all root certs are expected to have expired
- add easy cert fallback mechanism for macOS 10.11 and earlier
