### PR TITLE
Avoid deprecated arc4random_addrandom

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -375,7 +375,8 @@ def configure(conf, cstd = 'c99'):
 
     # Alignment
     if compiler_mode == 'gnu' and (7,) <= gcc_version(env):
-        env.AppendUnique(CXXFLAGS = ['-faligned-new'])
+        if not (compiler == 'clang' and env['PLATFORM'] == 'darwin'):
+            env.AppendUnique(CXXFLAGS = ['-faligned-new'])
 
     # Dependency files
     if depends and compiler_mode == 'gnu':

--- a/config/flatdistpkg/__init__.py
+++ b/config/flatdistpkg/__init__.py
@@ -798,7 +798,8 @@ def flat_dist_pkg_build(target, source, env):
 
     # flat packages require OS X 10.5+
     distpkg_target = env.get('distpkg_target', '10.5')
-    if distpkg_target.split('.') < '10.5'.split('.'):
+    ver = tuple([int(x) for x in distpkg_target.split('.')])
+    if ver < (10,5):
         raise Exception(
             'incompatible configuration: flat package and osx pre-10.5 (%s)'
             % distpkg_target)

--- a/src/cbang/openssl/SSLContext.cpp
+++ b/src/cbang/openssl/SSLContext.cpp
@@ -376,6 +376,7 @@ void SSLContext::loadSystemRootCerts() {
           valid = SecTrustEvaluateWithError(trust, NULL);
           LOG_DEBUG(5, "Called SecTrustEvaluateWithError()");
         } else {
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_15)
           SecTrustResultType result;
           err = SecTrustEvaluate(trust, &result); // macOS 10.3–10.15
           LOG_DEBUG(5, "Called SecTrustEvaluate()");
@@ -390,6 +391,7 @@ void SSLContext::loadSystemRootCerts() {
                 break;
             }
           }
+#endif
         }
       }
 

--- a/src/libevent/src/evutil_rand.c
+++ b/src/libevent/src/evutil_rand.c
@@ -195,8 +195,12 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
 void
 evutil_secure_rng_add_bytes(const char *buf, size_t n)
 {
+#ifdef __APPLE__
+	arc4random_stir();
+#else
 	arc4random_addrandom((unsigned char*)buf,
 	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
+#endif
 }
 
 void


### PR DESCRIPTION
Avoid deprecated arc4random_addrandom on osx
Fix pkg target version check
Don't use -faligned-new with clang on osx
Fix deprecated warning if target macos 10.15+

Use of -faligned-new breaks compatibility with macOS < 10.13.
Using c++17 is supposed to do the same thing when target is 10.13+.
I have not tested such.
Config for cores might want to add -faligned-new to ccflags explicitly when target 10.13+.
