### PR TITLE
Fix getExecutablePath on FreeBSD

### DIFF
--- a/src/cbang/os/SystemUtilities.cpp
+++ b/src/cbang/os/SystemUtilities.cpp
@@ -388,7 +388,7 @@ namespace cb {
       size_t len = PATH_MAX;
       path[0] = path[PATH_MAX] = 0;
 
-      if (sysctl(mib, 4, path, &len, 0, 0) || *path)
+      if (sysctl(mib, 4, path, &len, NULL, 0))
         THROW("Failed to get executable path: " <<  SysError());
 
       return (char *)path;


### PR DESCRIPTION
Without this patch, the following message is displayed when running CAMotics on FreeBSD:

ERROR:Exception: Failed to get executable path: Success