### PR TITLE
Osx updates 2022 06 22

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -299,7 +299,8 @@ def configure(conf, cstd = 'c99'):
             env.AppendUnique(LINKFLAGS = ['-Wl,-x'])
 
         if compiler == 'gnu': # Enable dead code removal
-            env.AppendUnique(LINKFLAGS = ['-Wl,--gc-sections'])
+            if env['PLATFORM'] != 'darwin':
+                env.AppendUnique(LINKFLAGS = ['-Wl,--gc-sections'])
             env.AppendUnique(CCFLAGS =
                              ['-ffunction-sections', '-fdata-sections'])
 
@@ -445,7 +446,7 @@ def configure(conf, cstd = 'c99'):
 
 
     # Don't link unneeded dynamic libs
-    if compiler == 'gnu':
+    if compiler == 'gnu' and env['PLATFORM'] != 'darwin':
         env.PrependUnique(LINKFLAGS = ['-Wl,--as-needed'])
 
 

--- a/src/cbang/openssl/SSLContext.cpp
+++ b/src/cbang/openssl/SSLContext.cpp
@@ -347,7 +347,12 @@ void SSLContext::loadSystemRootCerts() {
       // https://github.com/macports/macports-ports/blob/master/security/certsync/files/certsync.m
 
       if (err == errSecSuccess) {
+#if __clang__
         if (__builtin_available(macOS 10.14, *)) { // macOS 10.14+
+#else
+        Version vers = MacOSUtilities::getMacOSVersion();
+        if (vers >= Version(10, 14)) {
+#endif
           valid = SecTrustEvaluateWithError(trust, NULL);
           LOG_DEBUG(5, "Called SecTrustEvaluateWithError()");
         } else {

--- a/src/cbang/os/CPURegsAArch64.cpp
+++ b/src/cbang/os/CPURegsAArch64.cpp
@@ -52,6 +52,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <mach/machine.h>
+#include <string.h>
 #endif
 
 using namespace cb;


### PR DESCRIPTION
Only use __builtin_available with clang, which requires it
Don't use link flag --gc-sections on osx
Don't use link flag --as-needed on osx
Include string.h for memset using gcc
