### PR TITLE
Fix unbundled boost build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -57,6 +57,8 @@ for lib in 'zlib bzip2 lz4 sqlite3 expat boost libevent re2 libyaml'.split():
         Default(SConscript('src/%s/SConscript' % lib,
                            variant_dir = 'build/' + lib))
 
+if 'boost' not in disable_local:
+    env.CBDefine('HAVE_BOOST')
 
 # Source
 subdirs = [

--- a/config/build_info/__init__.py
+++ b/config/build_info/__init__.py
@@ -55,6 +55,8 @@ def svn_get_info():
 
 
 def git_get_info():
+    git = which('git')
+    if not git: return None, None
     revision, branch = None, None
 
     try:

--- a/config/cbang/__init__.py
+++ b/config/cbang/__init__.py
@@ -94,12 +94,20 @@ def configure(conf):
     env.AppendUnique(LIBPATH = [home + '/lib'])
 
     with open(home + '/include/cbang/config.h', 'r') as f:
-        with_openssl = f.read().find('#define HAVE_OPENSSL') != -1
+        config = f.read()
+        with_openssl = config.find('#define HAVE_OPENSSL') != -1
+        with_boost = config.find('#define HAVE_BOOST') != -1
 
     if not env.CBConfigEnabled('cbang-deps'):
         conf.CBConfig('cbang-deps', local = False, with_openssl = with_openssl)
 
-    conf.CBRequireLib('cbang-boost')
+    if with_boost:
+        conf.CBRequireLib('cbang-boost')
+    else:
+        conf.CBRequireLib('boost_filesystem')
+        conf.CBRequireLib('boost_iostreams')
+        conf.CBRequireLib('boost_regex')
+        conf.CBRequireLib('boost_system')
     conf.CBRequireLib('cbang')
     if platform.system() == 'FreeBSD': conf.CBRequireLib('sysinfo')
     conf.CBRequireCXXHeader('cbang/Exception.h')


### PR DESCRIPTION
Joseph,

Bundling is very unwelcome in Fedora, so when cbang is built as a shared library, then there is a need for 'cbang' tool to know somehow which boost to use. Perhaps my patch is not in line with your vision on how this should be implemented, but you would get the idea.

Thank you,
Sergey 