### PR TITLE
Fix install target & boost deps

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,7 +3,7 @@ import platform
 
 
 # Version
-version = '1.7.0'
+version = '1.7.2'
 libversion = '0'
 
 
@@ -143,7 +143,7 @@ for dir in subdirs:
     dir = prefix + '/include/cbang/' + dir
     install.append(env.Install(dir = dir, source = files))
 
-docs = ['README.md', 'COPYING']
+docs = ['README.md', 'LICENSE']
 docdir = env.get('docdir').replace('${prefix}', prefix)
 install.append(env.Install(dir = docdir, source = docs))
 

--- a/SConstruct
+++ b/SConstruct
@@ -35,9 +35,12 @@ env.Replace(RESOURCES_NS = 'cb')
 
 
 # Configure
+disable_local = env.get('disable_local', '')
+if hasattr(disable_local, 'split'): disable_local = disable_local.split()
 if not env.GetOption('clean'):
     conf.CBConfig('compiler')
-    conf.CBConfig('cbang-deps', with_openssl = env['with_openssl'])
+    conf.CBConfig('cbang-deps', with_openssl = env['with_openssl'], 
+        with_local_boost = 'boost' not in disable_local)
     env.CBDefine('USING_CBANG') # Using CBANG macro namespace
     if env['PLATFORM'] != 'win32': env.AppendUnique(CCFLAGS = ['-fPIC'])
 
@@ -49,8 +52,6 @@ env.Append(CPPPATH = ['#/include', '#/src', '#/src/boost'])
 # Build third-party libs
 force_local = env.get('force_local', '')
 if hasattr(force_local, 'split'): force_local = force_local.split()
-disable_local = env.get('disable_local', '')
-if hasattr(disable_local, 'split'): disable_local = disable_local.split()
 Export('env conf')
 resources_excludes = []
 for lib in 'zlib bzip2 lz4 sqlite3 expat boost libevent re2 libyaml'.split():

--- a/config/cbang/__init__.py
+++ b/config/cbang/__init__.py
@@ -9,9 +9,9 @@ def GetHome():
     return os.path.dirname(os.path.abspath(path))
 
 
-def configure_deps(conf, local = True, with_openssl = True):
+def configure_deps(conf, local = True, with_openssl = True, with_local_boost = True):
     env = conf.env
-
+    
     conf.CBConfig('ZLib', not local)
     conf.CBConfig('bzip2', not local)
     conf.CBConfig('XML', not local)
@@ -83,7 +83,12 @@ def configure_deps(conf, local = True, with_openssl = True):
                 'execinfo.h, bfd.h and libbfd needed for backtrace_debuger')
 
         env.CBDefine('CBANG_DEBUG_LEVEL=' + str(env.get('debug_level', 1)))
-
+        
+    if not with_local_boost:
+        conf.CBRequireLib('boost_filesystem')
+        conf.CBRequireLib('boost_iostreams')
+        conf.CBRequireLib('boost_regex')
+        conf.CBRequireLib('boost_system')
 
 def configure(conf):
     env = conf.env


### PR DESCRIPTION
Joseph,
when building as a shared lib with non-local `boost` the resulting `.so` get weak undefined symbols for boost, so the first commit fixes this. I hope I did everything correctly
The second commit is to fix the install target as you removed `COPYING` file.
Also, I bumped version in SConstruct for you, so could you please tag the code with `1.7.2` after merge (and possible corrections of my changes) 