### PR TITLE
Not a PR!!!

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ env.CBAddVariables(
     BoolVariable('with_openssl', 'Build with OpenSSL support', True),
     ('force_local', 'List of 3rd party libs to be built locally', ''),
     ('disable_local', 'List of 3rd party libs not to be built locally', ''))
-env.CBLoadTools('packager compiler cbang build_info resources')
+env.CBLoadTools('packager compiler cbang build_info resources testtool')
 conf = env.CBConfigure()
 
 

--- a/config/testtool/__init__.py
+++ b/config/testtool/__init__.py
@@ -1,0 +1,2 @@
+from testtool import generate
+from testtool import exists

--- a/config/testtool/testtool.py
+++ b/config/testtool/testtool.py
@@ -1,0 +1,5 @@
+def generate(env):
+    return 1
+
+def exists(env):
+    return 1


### PR DESCRIPTION
Joseph, 

this is not a PR, but a question. I want to extend the scons config tools by adding a submodule keeping its original name intact. The framework fails to load with circular reference error. How this should be done?

Thank you, 
Sergey