### PR TITLE
Add SystemInfo::getPerformanceCPUCount()

### DIFF
--- a/src/cbang/os/SystemInfo.h
+++ b/src/cbang/os/SystemInfo.h
@@ -60,6 +60,7 @@ namespace cb {
     SystemInfo(Inaccessible);
 
     uint32_t getCPUCount() const;
+    uint32_t getPerformanceCPUCount() const;
     ThreadsType getThreadsType() {return threadsType;}
 
     uint64_t getMemoryInfo(memory_info_t type) const;


### PR DESCRIPTION
Currently only implemented for macOS.

Would be useful for Linux and Windows, for both ARM and Intel big.little.
