### PR TITLE
Osx updates 2022 11 15

### DIFF
--- a/config/flatdistpkg/__init__.py
+++ b/config/flatdistpkg/__init__.py
@@ -1,7 +1,5 @@
 '''  flatdistpkg '''
 
-from __future__ import print_function
-
 import os, platform, shutil
 import config
 import zipfile

--- a/config/pkg/__init__.py
+++ b/config/pkg/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 '''Builds an OSX single application package'''
 
 import os
@@ -90,7 +88,7 @@ def build_function(target, source, env):
 
     if env.get('sign_id_installer') and not env.get('sign_disable'):
         cmd += ['--sign', env.get('sign_id_installer')]
-        if 'sign_keychain' in env:
+        if env.get('sign_keychain'):
             cmd += ['--keychain', env.get('sign_keychain')]
 
     cmd += [str(target[0])]


### PR DESCRIPTION
I left in support for altool because current fah-build workers use it, and cbang is open source.

I didn't want everyone to be forced to use Xcode 13+ and macOS 11.3+ for notarization.

In Fall 2023, altool will stop working for notarization. Support can be removed then.
