### PR TITLE
Glob osx sign_tools/apps paths that contain `*`

### DIFF
--- a/config/flatdistpkg/__init__.py
+++ b/config/flatdistpkg/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import glob
 import re
 import config
 import zipfile
@@ -178,16 +179,20 @@ def build_component_pkg(info, env):
     # if any apps/tools should be codesign'd do that now
     # assumes project didn't do it when creating its distroot
     # TODO clone env and add info so all sign_ vars can be overridden
-    sign_apps = info.get('sign_apps', [])
-    for path in sign_apps:
-        if not path.startswith('/'):
-            path = os.path.join(root, path)
+    paths = []
+    for path in info.get('sign_apps', []):
+      if '*' in path: paths += glob.glob(path, root_dir = root)
+      else: paths.append(path)
+    for path in paths:
+        if not path.startswith('/'): path = os.path.join(root, path)
         env.SignApplication(path)
 
-    sign_tools = info.get('sign_tools', [])
-    for path in sign_tools:
-        if not path.startswith('/'):
-            path = os.path.join(root, path)
+    paths = []
+    for path in info.get('sign_tools', []):
+      if '*' in path: paths += glob.glob(path, root_dir = root)
+      else: paths.append(path)
+    for path in paths:
+        if not path.startswith('/'): path = os.path.join(root, path)
         env.SignExecutable(path)
 
     cmd = ['pkgbuild',

--- a/config/pkg/__init__.py
+++ b/config/pkg/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import glob
 
 from SCons.Script import *
 
@@ -74,16 +75,20 @@ def build_function(target, source, env):
             pkg_resources = [[pkg_resources, '.']]
         env.CopyToPackage(pkg_resources, build_dir_resources)
 
-    sign_apps = env.get('sign_apps', [])
-    for path in sign_apps:
-        if not path.startswith('/'):
-            path = os.path.join(root_dir, path)
+    paths = []
+    for path in info.get('sign_apps', []):
+      if '*' in path: paths += glob.glob(path, root_dir = root)
+      else: paths.append(path)
+    for path in paths:
+        if not path.startswith('/'): path = os.path.join(root, path)
         env.SignApplication(path)
 
-    sign_tools = env.get('sign_tools', [])
-    for path in sign_tools:
-        if not path.startswith('/'):
-            path = os.path.join(root_dir, path)
+    paths = []
+    for path in info.get('sign_tools', []):
+      if '*' in path: paths += glob.glob(path, root_dir = root)
+      else: paths.append(path)
+    for path in paths:
+        if not path.startswith('/'): path = os.path.join(root, path)
         env.SignExecutable(path)
 
     # build component pkg


### PR DESCRIPTION
glob.glob osx sign_tools/apps paths that contain `*`

This lets one just use
```
  'sign_tools' : ['usr/local/bin/*'],
  'sign_apps'  : ['Applications/*.app']
```
when multiple tools/apps are to be signed.
