### PR TITLE
Fix SystemUtilities::rotate max files pattern

### DIFF
--- a/src/cbang/os/SystemUtilities.cpp
+++ b/src/cbang/os/SystemUtilities.cpp
@@ -763,7 +763,7 @@ namespace cb {
         else searchDir = dir;
 
         string pattern =  String::escapeRE(base) +
-          "-[0-9]{8}-[0-9]{6}\\." + String::escapeRE(ext);
+          "-[0-9]{8}-[0-9]{6}" + String::escapeRE(ext);
         if (!compExt.empty()) pattern += "(" + String::escapeRE(compExt) + ")?";
 
         DirectoryWalker walker(searchDir, pattern, 1);


### PR DESCRIPTION
Because ext now includes a dot, the RE had `\.\.`, which failed to find any files to remove.

Pattern was `log-[0-9]{8}-[0-9]{6}\.\.txt`

This broke both `log-rotate-max` and config rotate max.
