### PR TITLE
Support osx packaging pre_sign_callback

### DIFF
--- a/config/flatdistpkg/__init__.py
+++ b/config/flatdistpkg/__init__.py
@@ -137,6 +137,10 @@ def build_component_pkg(info, env):
     if not os.path.isdir(root) and not pkg_nopayload:
         raise Exception('%s component root does not exist! %s' % (name, root))
 
+    callback = info.get('pre_sign_callback')
+    if callback:
+        callback(info)
+
     # if any apps/tools should be codesign'd do that now
     # assumes project didn't do it when creating its distroot
     # TODO clone env and add info so all sign_ vars can be overridden


### PR DESCRIPTION
I need this to add an icon to `Folding@home.url` because the python packager functions do not preserve resource forks or other metadata.