### PR TITLE
Fix detection of temporary resource files

### DIFF
--- a/config/resources/__init__.py
+++ b/config/resources/__init__.py
@@ -229,7 +229,7 @@ def modify_targets(target, source, env):
 
 def generate(env):
   env.SetDefault(RESOURCES_NS = '')
-  env.SetDefault(RESOURCES_EXCLUDES = [r'\.svn', r'.*~'])
+  env.SetDefault(RESOURCES_EXCLUDES = [r'\.svn', r'~$'])
 
   bld = env.Builder(action = resources_build,
                     source_factory = SCons.Node.FS.Entry,


### PR DESCRIPTION
'.*~' matches ~ in the path at any position, whereas '~$' matches ~ only at the end of the file name.