### PR TITLE
Fix #167 build fails when OpenSSL is not installed

### DIFF
--- a/src/cbang/event/Connection.cpp
+++ b/src/cbang/event/Connection.cpp
@@ -76,7 +76,9 @@ void Connection::setSocket(const SmartPointer<Socket> &socket) {
   this->socket = socket;
   if (socket.isSet()) socket->setAutoClose(false);
   setFD(socket.isSet() ? socket->get() : -1);
+#ifdef HAVE_OPENSSL
   if (getFD() != -1 && getSSL().isSet()) getSSL()->setFD(getFD());
+#endif // HAVE_OPENSSL
 }
 
 

--- a/src/cbang/event/Port.cpp
+++ b/src/cbang/event/Port.cpp
@@ -34,6 +34,7 @@
 #include "Server.h"
 #include "Event.h"
 
+#include <cbang/Catch.h>
 #include <cbang/net/Socket.h>
 #include <cbang/log/Logger.h>
 #include <cbang/os/SysError.h>
@@ -93,8 +94,13 @@ void Port::accept() {
 
     try {
       server.accept(peerAddr, newSocket, sslCtx);
-    } catch (const SSLException &e) {
+#ifdef HAVE_OPENSSL
+    }
+    catch (const SSLException& e) {
       LOG_DEBUG(4, e.getMessage());
     }
+#else
+    } CATCH_ERROR;
+#endif // HAVE_OPENSSL
   }
 }

--- a/src/cbang/ws/Websocket.cpp
+++ b/src/cbang/ws/Websocket.cpp
@@ -40,6 +40,8 @@
 
 #ifdef HAVE_OPENSSL
 #include <cbang/openssl/Digest.h>
+#else
+#include <cbang/net/Base64.h>
 #endif
 
 #include <cstring> // memcpy()


### PR DESCRIPTION
Fixes #167.

Encountered when trying to build in a minimal Windows development environment where none of the optional dependencies were installed. Traced down to the following specific commits which caused the compile issues:
1. `76d7bec8` - Preliminary basic HTTP proxy support (2024-07-11) `Connection.cpp` (line 78). `HAVE_OPENSSL` preprocessor missing from newly added line. REVISIT: Not sure if the correct fix is to preprocess this line, or add an empty implementation of `setFD` to `ssh.h` when preprocessed.
2. `e91d3291` - Fix reconnect outgoing and reorg event connect logic (2023-08-09) `Port.cpp` (line 94).  `HAVE_OPENSSL` preprocessor removed but `SSLException` catch left behind unprotected by the preprocessor. REVISIT: Corrected by adding generic `CATCH_ERROR` macro, but sure if this is the desired way to fix.
3. `632ae02f` + `29d33aea` - `Websocket.cpp` (lines 38-42 & 275) `Websocket.cpp` (lines 38-42 & 275) `HAVE_OPENSSL` preprocessor added around `cbang/openssl/Digest.h` include combined with later added `writeRequest` which requires `cbang/net/Base64.h` to allow `Base64` encoding.