### PR TITLE
Load libOpenCL.so.1 instead of libOpenCL.so

### DIFF
--- a/src/cbang/hw/OpenCLLibrary.cpp
+++ b/src/cbang/hw/OpenCLLibrary.cpp
@@ -56,7 +56,7 @@ static const char *openclLib =
   "/System/Library/Frameworks/OpenCL.framework/OpenCL";
 
 #else
-static const char *openclLib = "libOpenCL.so";
+static const char *openclLib = "libOpenCL.so.1";
 #endif
 
 


### PR DESCRIPTION
The generic OpenCL ICD loader packages (ocl-icd-libopencl1/ocl-icd/libOpenCL1) provide libOpenCL.so.1.

libOpenCL.so is part of the development packages (ocl-icd-opencl-dev/ocl-icd-devel), which we are unnecessarily forcing users to install.