### PR TITLE
Fix run time exception in ServerApplication using  FEATURE_LIFELINE

### DIFF
--- a/src/cbang/ServerApplication.cpp
+++ b/src/cbang/ServerApplication.cpp
@@ -56,7 +56,7 @@ ServerApplication::ServerApplication(const string &name,
   if (hasFeature(FEATURE_LIFELINE))
     cmdLine.addTarget("lifeline", lifeline, "The application will watch for "
                       "this process ID and exit if it goes away.  Usually the "
-                      "calling process' PID.")->setType(Option::TYPE_INTEGER);
+                      "calling process' PID.");
 
   if (!hasFeature(FEATURE_SERVER)) return;
 


### PR DESCRIPTION
addTarget calls setDefault internally so setType afterward throws an exception. The type should be inferred.