### PR TITLE
Enable systemd support only with sd-device present

### DIFF
--- a/config/cbang/__init__.py
+++ b/config/cbang/__init__.py
@@ -101,9 +101,11 @@ def configure_deps(conf, local = True, with_openssl = True,
             raise SCons.Errors.StopError('Need CoreServices, IOKit, Security '
                                          '& CoreFoundation frameworks')
 
-    # sd-bus
+    # sd-bus and sd-device
     if (env['PLATFORM'] == 'posix' and
-        conf.CBCheckCHeader('systemd/sd-bus.h') and conf.CBCheckLib('systemd')):
+        conf.CBCheckCHeader('systemd/sd-bus.h') and
+        conf.CBCheckCHeader('systemd/sd-device.h') and
+        conf.CBCheckLib('systemd')):
         conf.CBCheckLib('cap')
         env.CBConfigDef('HAVE_SYSTEMD')
 


### PR DESCRIPTION
fah-client now utilizes the sd-device API. Requires systemd 240 or later.