### PR TITLE
Revert "Enable systemd support only with sd-device present"

### DIFF
--- a/config/cbang/__init__.py
+++ b/config/cbang/__init__.py
@@ -101,11 +101,9 @@ def configure_deps(conf, local = True, with_openssl = True,
             raise SCons.Errors.StopError('Need CoreServices, IOKit, Security '
                                          '& CoreFoundation frameworks')
 
-    # sd-bus and sd-device
+    # sd-bus
     if (env['PLATFORM'] == 'posix' and
-        conf.CBCheckCHeader('systemd/sd-bus.h') and
-        conf.CBCheckCHeader('systemd/sd-device.h') and
-        conf.CBCheckLib('systemd')):
+        conf.CBCheckCHeader('systemd/sd-bus.h') and conf.CBCheckLib('systemd')):
         conf.CBCheckLib('cap')
         env.CBConfigDef('HAVE_SYSTEMD')
 


### PR DESCRIPTION
This reverts commit dcd7e5d1f031b4d2e73d1c58d8e72e885ef8bb11.

sd-device usage in fah-client was dropped.