### PR TITLE
Add clang lto option

### DIFF
--- a/config/compiler/__init__.py
+++ b/config/compiler/__init__.py
@@ -255,6 +255,10 @@ def configure(conf, cstd = 'c99'):
             env.AppendUnique(LINKFLAGS = ['-flto=auto'])
             env.AppendUnique(CCFLAGS   = ['-flto=auto'])
 
+        elif lto and compiler == 'clang':
+            env.AppendUnique(LINKFLAGS = ['-flto'])
+            env.AppendUnique(CCFLAGS   = ['-flto'])
+
         env.CBDefine('NDEBUG')
 
 


### PR DESCRIPTION
Client appears to run fine.
Allegedly, `-flto=thin` is recommended.
But full lto for client build only adds 20 seconds add cuts size by over 4MiB (1MiB more than lto thin).
Assume negligible performance benefits for client.

According to AI, `-flto` requires gcc 10+.
So you might want

```python
        if lto and compiler == 'gnu' and (10,) <= gcc_version(env): 
```