### PR TITLE
Windows patch for socket accept

### DIFF
--- a/src/cbang/net/Socket.cpp
+++ b/src/cbang/net/Socket.cpp
@@ -298,8 +298,15 @@ SmartPointer<Socket> Socket::accept(SockAddr &addr, unsigned flags) {
     // Peek at the buffer without removing data to see if it's still alive
     // This helps prevent us from wasting time on connections that are dead
     char buf;
+    SysError::clear();
     int ret = recv(s, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
-    if (!ret || (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+    int err = SysError::get();
+
+#ifdef _WIN32
+    if (!ret || (ret < 0 && err != WSAEWOULDBLOCK)) {
+#else
+    if (!ret || (ret < 0 && err != EAGAIN && err != EWOULDBLOCK)) {
+#endif
       close(s); // The client already sent FIN or an error occurred
       return 0;
     }


### PR DESCRIPTION
Socket peek to test for dead connections on Windows was checking the Linux flags instead of checking the WinSock flags like read() and write() implementations do.

This appears to be the root cause of the WebSocket connection errors on the FAH web client.  Relates to the following other tickets:
* https://github.com/FoldingAtHome/fah-web-client-bastet/issues/215
* https://github.com/FoldingAtHome/fah-web-client-bastet/issues/214
* https://github.com/FoldingAtHome/fah-client-bastet/issues/287
* https://github.com/FoldingAtHome/fah-client-bastet/issues/429

This needs review by someone deeply familiar with the code.  This fixes the issue for me on Windows deployments of the FAH v8 client, but I don't know what else may be affected by this library.

NOTE: While investigating this issue with the help of GPT, it was suggested that the most appropriate solution is to not peek at the socket on Windows systems at all (or any system) during the accept.  I left in the code that does peek but checks the correct error type for Windows.  I wasn't sure if the call to `SysError::Clear()` and `SysError::get()` would have any unintended side-effects on `errno` so i changed the non-Windows check to use `err` now, this matches the conditional implementation in `read()` and `write()`.

With this change, Windows socket immediately connects every time, and i can hit F5 multiple times in a row and it reconnects immediately and maintains the local resource flag correctly.  Testing on Linux (Ubuntu 24.04.4) the behavior is the same, no regression that I could detect.