### PR TITLE
Fix getUsableMemory() and getFreeSwapMemory() on Windows

### DIFF
--- a/src/cbang/os/win/WinSystemInfo.cpp
+++ b/src/cbang/os/win/WinSystemInfo.cpp
@@ -72,11 +72,16 @@ uint64_t WinSystemInfo::getMemoryInfo(memory_info_t type) const {
   GlobalMemoryStatusEx(&info);
 
   switch (type) {
-  case MEM_INFO_TOTAL: return (uint64_t)info.ullTotalPhys;
-  case MEM_INFO_FREE:  return (uint64_t)info.ullAvailPhys;
-  case MEM_INFO_SWAP:  return (uint64_t)info.ullAvailPageFile;
+  case MEM_INFO_TOTAL:
+    return (uint64_t)info.ullTotalPhys;
+
+  case MEM_INFO_FREE:
   case MEM_INFO_USABLE:
-    return (uint64_t)(info.ullAvailPhys + info.ullAvailPageFile);
+    return (uint64_t)info.ullAvailPhys;
+
+  case MEM_INFO_SWAP:
+    return info.ullAvailPageFile > info.ullAvailPhys ?
+      (uint64_t)(info.ullAvailPageFile - info.ullAvailPhys) : 0;
   }
 
   return 0;


### PR DESCRIPTION
ullAvailPhys is the closest equivalent to Linux's MemAvailable. MEMORYSTATUSEX does not expose a separate MemFree-like value.

For swap, ullAvailPageFile includes space that can be committed to physical memory, so we subtract ullAvailPhys to approximate the actual free swap space, following Zabbix's approach:

https://github.com/zabbix/zabbix/blob/7.4.11/src/libs/zbxsysinfo/win32/swap.c#L130-L137

Closes #208